### PR TITLE
Prepend module name (sys) to variable assignment

### DIFF
--- a/example/mdl/generate_mdl_feed.py
+++ b/example/mdl/generate_mdl_feed.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     outfile = sys.argv[1]
     localcsv = None 
     if len(sys.argv) > 2:
-        localcsv = argv[2]
+        localcsv = sys.argv[2]
 
     bytes = create(localcsv)
     open(outfile, "w").write(bytes)


### PR DESCRIPTION
Minor fix to facilitate usage of localcsv option in MDL feed generator.
