### PR TITLE
Missing Documentation and RAW IOC example did not handle Report "Descriptions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ A `report` is a JSON structure with the following entries:
 | `title`        | REQUIRED | A one-line title describing this report.| 
 | `score`        | REQUIRED | The severity of this report from -100 to 100, with 100 most critical.| 
 | `iocs`         | REQUIRED | The IOCs for this report.  A match on __any__ IOC will cause the activity to be tagged with this report id.  The IOC format is described below.| 
+| `tags`         | OPTIONAL | A comma separated list of identifiers to tag the report. |
+| `description`  | OPTIONAL | A description of the report. |
 
 ### iocs
 
@@ -189,7 +191,7 @@ An example `reports` list with two `report` structures, each with one IPv4 IOC, 
       },
       "link": "https://www.dan.me.uk/tornodes",
       "id": "TOR-Node-100.2.142.8",
-      "title": "As of Wed Oct  2 20:09:48 2013 GMT, 100.2.142.8 has been a TOR exit for 26 days, 0:44:42. Contact: Adam Langley <agl@imperialviolet.org>"
+      "title": "As of Wed Oct  2 20:09:48 2013 GMT, 100.2.142.8 has been a TOR exit for 26 days, 0:44:42. Contact: Adam Langley <xxx@xxxviolet.org>"
     },
     {
       "timestamp": 1380773388,
@@ -200,7 +202,7 @@ An example `reports` list with two `report` structures, each with one IPv4 IOC, 
       },
       "link": "https://www.dan.me.uk/tornodes",
       "id": "TOR-Node-100.4.7.69",
-      "title": "As of Wed Oct  2 20:09:48 2013 GMT, 100.4.7.69 has been a TOR exit for 61 days, 2:07:23. Contact: GPG KeyID: 0x1F40CBDC Jeremy <jeremy@acjlaw.net>"
+      "title": "As of Wed Oct  2 20:09:48 2013 GMT, 100.4.7.69 has been a TOR exit for 61 days, 2:07:23. Contact: GPG KeyID: 0x1F40CBDC Jeremy <jeremy@xxxlaw.net>"
     }
   ]
 ```

--- a/example/raw/generate_feed_from_raw_iocs.py
+++ b/example/raw/generate_feed_from_raw_iocs.py
@@ -1,5 +1,11 @@
 # stdlib imports
-import re , sys , time ,  json , optparse , socket , base64 , hashlib
+import re
+import sys
+import time
+import optparse
+import socket
+import base64
+import hashlib
 
 # cb imports
 sys.path.insert(0, "../../")
@@ -81,7 +87,7 @@ def build_reports(options):
         fields['tags'] = options.tags.split(',')
     
     if options.description is not None:
-        fields['descrpition'] = options.description
+        fields['description'] = options.description
     
     if len(ips) > 0:
         fields['iocs']['ipv4'] = ips

--- a/example/raw/generate_feed_from_raw_iocs.py
+++ b/example/raw/generate_feed_from_raw_iocs.py
@@ -1,13 +1,5 @@
 # stdlib imports
-import re
-import sys
-import time
-import urllib
-import json
-import optparse
-import socket
-import base64
-import hashlib
+import re , sys , time ,  json , optparse , socket , base64 , hashlib
 
 # cb imports
 sys.path.insert(0, "../../")
@@ -87,6 +79,9 @@ def build_reports(options):
    
     if options.tags is not None: 
         fields['tags'] = options.tags.split(',')
+    
+    if options.description is not None:
+        fields['descrpition'] = options.description
     
     if len(ips) > 0:
         fields['iocs']['ipv4'] = ips


### PR DESCRIPTION
Added OPTIONAL fields to the report json definition in README.md.  

Concatenated the standard lib imports, deleted unused imports, added handling of the description field for reports.

Also, the tor node examples contained some email addresses which I've modified to be, hopefully, non-existent.