### PR TITLE
Adding -D description to the parser options

### DIFF
--- a/example/raw/generate_feed_from_raw_iocs.py
+++ b/example/raw/generate_feed_from_raw_iocs.py
@@ -175,6 +175,8 @@ def _build_cli_parser():
                       help="Report Name")
     parser.add_option("-g", "--tags", action="store", type="string", dest="tags",
                       help="Optional comma-delimited report tags")
+    parser.add_option("-D", "--description", action="store", type="string", dest="description",
+                      help="A brief description of the report.")
 
     return parser
 


### PR DESCRIPTION
Forgot to add a parser.option to handle the description option.